### PR TITLE
Added .gitignore to application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node modules
+node_modules/
+
+# Logs
+*.log
+
+# Environment variables
+.env
+
+# Build output
+dist/
+build/
+
+# macOS .DS_Store files
+.DS_Store


### PR DESCRIPTION
Add .gitignore to exclude unnecessary and sensitive files

- Exclude node_modules, .env, and other system-specific files
- Prevent accidental inclusion of sensitive data in version control
